### PR TITLE
Sort folder_factories-actions in factories menu translated in Plone domain

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Sort folder_factories-actions in factories menu translated in Plone domain.
+  [jone]
 
 
 2.2.1 (2013-04-16)

--- a/ftw/contentmenu/menu.py
+++ b/ftw/contentmenu/menu.py
@@ -260,6 +260,7 @@ class FactoriesMenu(menu.FactoriesMenu):
 
         # order the actions
         factories.sort(key=lambda x: translate(x.get('title', u''),
+                                               domain='plone',
                                                context=request))
 
         return self._post_cleanup_factories(context, request, factories)


### PR DESCRIPTION
This is only relevant when adding actions to the "folder_factories" category.
Those actions are translated in the Plone domain, therefore they should also be translated in this domain while sorting.
The titles of actual FTIs are message objects, therefore the domain is not relevant for those.

@maethu please take a look
