### PR TITLE
Remove permissioncheck for workflowaction "advanced"

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.2.2 (unreleased)
 ------------------
 
+- Remove permissioncheck for workflowaction 'advanced'
+  [elioschmutz]
+
 - Sort folder_factories-actions in factories menu translated in Plone domain.
   [jone]
 

--- a/ftw/contentmenu/menu.py
+++ b/ftw/contentmenu/menu.py
@@ -71,7 +71,7 @@ class CombinedActionsWorkflowMenu(menu.ActionsMenu, menu.WorkflowMenu):
         return results
 
     # workflow menu items
-    # 'advanced...' and 'policy...' items are only visible for managers
+    # 'policy...' item is only visible for managers
     def getWorkflowMenuItems(self, context, request):
         """Return menu item entries in a TAL-friendly form."""
         results = []
@@ -128,7 +128,7 @@ class CombinedActionsWorkflowMenu(menu.ActionsMenu, menu.WorkflowMenu):
 
         url = context.absolute_url()
 
-        if len(results) > 0 and _checkPermission('Manage portal', context):
+        if len(results) > 0:
             results.append({
                     'title': _(u'label_advanced', default=u'Advanced...'),
                     'description': '',

--- a/ftw/contentmenu/tests/test_menu.py
+++ b/ftw/contentmenu/tests/test_menu.py
@@ -82,15 +82,6 @@ class TestActionsMenu(unittest.TestCase):
         self.assertIn('workflow-transition-submit',
                       [a['extra']['id'] for a in actions])
 
-    def test_workflowmenu_items_advanced(self):
-        actions = self.menu.getWorkflowMenuItems(self.folder.doc1,
-                                                 self.request)
-        self.assertNotIn('advanced', [a['extra']['id'] for a in actions])
-        setRoles(self.portal, TEST_USER_ID, ['Manager'])
-        actions = self.menu.getWorkflowMenuItems(self.folder.doc1,
-                                                 self.request)
-        self.assertIn('advanced', [a['extra']['id'] for a in actions])
-
 
 class TestFactoriesMenu(unittest.TestCase):
 


### PR DESCRIPTION
@maethu @buchi @jone The permissioncheck for the advanced action is not nessesary:
- The view itself is protected
- The link is just visible if the user is able to do transactions
- The advanced view is anyway accessible over the folder_contents view
