### PR TITLE
Add plone.protect 3.0 "auto" support: automatically add token to transition actions

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add plone.protect 3.0 "auto" support: automatically add token to transition actions.
+  [jone]
 
 
 2.3.1 (2014-10-20)

--- a/ftw/contentmenu/menu.py
+++ b/ftw/contentmenu/menu.py
@@ -11,6 +11,13 @@ from zope.i18n import translate
 from zope.interface import implements
 
 
+try:
+    from plone.protect.utils import addTokenToUrl
+except ImportError:
+    def addTokenToUrl(url, req=None):
+        return url
+
+
 class CombinedActionsWorkflowMenu(menu.ActionsMenu, menu.WorkflowMenu):
     """ Combines the default actions- and the default workflow menu
     """
@@ -116,7 +123,7 @@ class CombinedActionsWorkflowMenu(menu.ActionsMenu, menu.WorkflowMenu):
                 results.append({
                         'title': action['title'],
                         'description': description,
-                        'action': actionUrl,
+                        'action': addTokenToUrl(actionUrl),
                         'selected': False,
                         'icon': None,
                         'extra': {'id': 'workflow-transition-' +


### PR DESCRIPTION
When `plone.protect >= 3` is installed, we have automatic CSRF protection.
This means all write requests have to have an `_authenticator` param.

`plone.protect` provides a `addTokenToUrl` method which is used for adding the param.
If `plone.protect` is older, we use a dummy function doing nothing.

I have not added tests actually testing the token since we'd have to update plone.protect which will get us some trouble. This should be save enough.

/cc @lukasgraf @phgross @maethu 
